### PR TITLE
feat(RSS-2520): adiciona chave_nota no detalhe CNAB400 Bradesco

### DIFF
--- a/lib/brcobranca/remessa/cnab400/bradesco.rb
+++ b/lib/brcobranca/remessa/cnab400/bradesco.rb
@@ -193,6 +193,7 @@ module Brcobranca
             detalhe << pagamento.mensagem.format_size(60)             # 2a mensagem - verificar                     X[60]       335 a 394
           end
           detalhe << sequencial.to_s.rjust(6, '0')                    # numero do registro do arquivo               9[06]       395 a 400
+          detalhe << pagamento.chave_nota.to_s.ljust(44, " ")         # Chave da Nota Eletrônica                    X(44)       401 a 444
           detalhe
         end
 


### PR DESCRIPTION
## Resumo

Adiciona o campo **Chave da Nota Eletrônica** (`chave_nota`) no registro de detalhe do remessa CNAB400 do Bradesco.

O campo ocupa as posições **401 a 444** (44 caracteres), alinhado à esquerda com espaços — seguindo o mesmo padrão já implementado no CNAB444 Paulista.

## Mudanças

- `lib/brcobranca/remessa/cnab400/bradesco.rb`: adiciona `pagamento.chave_nota` ao final do detalhe, após o sequencial (posição 395-400)

## Ticket

RSS-2520